### PR TITLE
adapt to latest changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
   },
   "devDependencies": {
     "@types/glob": "^8.0.0",
-    "@types/mocha": "^10.0.0",
+    "@types/mocha": "^10.0.1",
     "@types/node": "18.11.9",
     "@types/sinon": "^10.0.14",
     "@types/vscode": "^1.69.0",
@@ -216,7 +216,7 @@
     "@flyde/runtime": "^0.5.0",
     "@tsconfig/node16": "^1.0.3",
     "@types/fs-extra": "^11.0.1",
-    "@types/react": "^18.0.25",
+    "@types/react": "^18.2.0",
     "@vscode/extension-telemetry": "^0.7.5",
     "@vscode/vsce": "^2.19.0",
     "callsite": "^1.0.0",

--- a/src/editor/open-flyde-panel.ts
+++ b/src/editor/open-flyde-panel.ts
@@ -22,7 +22,7 @@ const getScriptTagsFromReactAppHtml = async (
   isDev: boolean
 ) => {
   if (isDev) {
-    return '<script defer="defer" src="http://localhost:3000/editor/static/js/bundle.js"></script>';
+    return '<script defer="defer" src="http://localhost:3000/static/js/bundle.js"></script>';
   } else {
     // this assumes react scripts will always remain on the same structure
     const html = (


### PR DESCRIPTION
https://github.com/FlydeHQ/flyde/pull/48 removed the need for "/editor" basename
This PR adapts to this change when running locally